### PR TITLE
Database Docker Container Setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/node_modules
 config/config.js
+.env

--- a/README.md
+++ b/README.md
@@ -17,3 +17,6 @@ Kiosks connected to the internet will be located at the top of the trailheads. T
 
 Remote kiosks will be scattered amongst the trails at junctions and popular areas. These will be equipped with Bluetooth pinging that will count passing by foot traffic of hikers whose Bluetooth is turned on. This data will be downloaded manually from trail managers and then uploaded to the database.
 
+## Docker Database Setup
+
+First, create a .env file in the root directory of your repository and add a line `DB_PASSWORD=<your_password_here>`, replacing `<your_password_here>` with your desired database password. Then, run the docker container by navigating to the directory in your terminal and executing `docker-compose up`. To connect to the running PostgreSQL container via pgAdmin4, create a new server and under the Connection tab set the Host name/address to `host.docker.internal`, Port to `5432`, Maintenance database to `postgres`, Username to `adirontech`, and Password to the one you specified in the .env file.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  db:
+    image: "postgres:latest"
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_DB: "trek-db"
+      POSTGRES_USER: "adirontech"
+      POSTGRES_PASSWORD: ${DB_PASSWORD}


### PR DESCRIPTION
Created a docker-compose.yml file to create a docker container for a postgres database. Username set to be `adirontech`. Password for database account is specified via a local .env file in the same directory (not committed to repository, must be created locally).

Docker container can be started by running `docker-compose up` command from a terminal in the repository.